### PR TITLE
Add RabbitMQ support with dynamic message broker detection

### DIFF
--- a/blocks_genesis/__init__.py
+++ b/blocks_genesis/__init__.py
@@ -5,6 +5,7 @@ from blocks_genesis._database.db_context import DbContext
 from blocks_genesis._tenant.tenant import Tenant
 from blocks_genesis._tenant.tenant_service import TenantService, get_tenant_service
 from blocks_genesis._message.azure.azure_message_client import AzureMessageClient
+from blocks_genesis._message.rabbit_mq.rabbit_message_client import RabbitMessageClient
 from blocks_genesis._core.api import close_lifespan, configure_lifespan, configure_middlewares, fast_api_app
 from blocks_genesis._core.worker import WorkerConsoleApp
 from blocks_genesis._core.configuration import get_configurations, load_configurations
@@ -14,7 +15,7 @@ from blocks_genesis._message.consumer_message import ConsumerMessage
 from blocks_genesis._message.message_client import MessageClient
 from blocks_genesis._utilities.crypto_service import CryptoService
 from blocks_genesis._auth.auth import authorize
-from blocks_genesis._message.message_configuration import AzureServiceBusConfiguration, MessageConfiguration
+from blocks_genesis._message.message_configuration import AzureServiceBusConfiguration, RabbitMqConfiguration, ConsumerSubscription, MessageConfiguration
 from blocks_genesis._core.change_context import change_context
 from blocks_genesis._core.azure_key_vault import AzureKeyVault
 
@@ -28,6 +29,9 @@ __all__ = [
     "TenantService",
     "get_tenant_service",
     "AzureMessageClient",
+    "RabbitMessageClient",
+    "RabbitMqConfiguration",
+    "ConsumerSubscription",
     "MessageConfiguration",
     "close_lifespan",
     "configure_lifespan",

--- a/blocks_genesis/_core/api.py
+++ b/blocks_genesis/_core/api.py
@@ -6,13 +6,14 @@ from starlette.middleware.cors import CORSMiddleware
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from blocks_genesis._cache.cache_provider import CacheProvider
 from blocks_genesis._cache.redis_client import RedisClient
-from blocks_genesis._core.secret_loader import SecretLoader
+from blocks_genesis._core.secret_loader import SecretLoader, get_blocks_secret
 from blocks_genesis._database.db_context import DbContext
 from blocks_genesis._database.mongo_context import MongoDbContextProvider
 from blocks_genesis._lmt.log_config import configure_logger
 from blocks_genesis._lmt.mongo_log_exporter import MongoHandler
 from blocks_genesis._lmt.tracing import configure_tracing
 from blocks_genesis._message.azure.azure_message_client import AzureMessageClient
+from blocks_genesis._message.rabbit_mq.rabbit_message_client import RabbitMessageClient
 from blocks_genesis._message.message_configuration import MessageConfiguration
 from blocks_genesis._middlewares.global_exception_middleware import GlobalExceptionHandlerMiddleware
 from blocks_genesis._middlewares.tenant_middleware import TenantValidationMiddleware
@@ -41,7 +42,13 @@ async def configure_lifespan(name: str, message_config: MessageConfiguration):
     await initialize_tenant_service()
     DbContext.set_provider(MongoDbContextProvider())
     
-    AzureMessageClient.initialize(message_config)
+    if message_config is not None:
+        message_config.connection = message_config.connection or get_blocks_secret().MessageConnectionString
+        message_config.resolve_provider()
+        if message_config.rabbit_mq_configuration is not None:
+            RabbitMessageClient.initialize(message_config)
+        if message_config.azure_service_bus_configuration is not None:
+            AzureMessageClient.initialize(message_config)
 
 
 
@@ -64,8 +71,15 @@ def fast_api_app(lifespan, **kwargs: FastAPI) -> FastAPI:
     
 async def close_lifespan():
     logger.info("Shutting down services...")
-    
-    await AzureMessageClient.get_instance().close()
+
+    try:
+        await RabbitMessageClient.get_instance().close()
+    except RuntimeError:
+        pass
+    try:
+        await AzureMessageClient.get_instance().close()
+    except RuntimeError:
+        pass
     # Shutdown logic
     if hasattr(MongoHandler, '_mongo_logger') and MongoHandler._mongo_logger:
         MongoHandler._mongo_logger.stop()

--- a/blocks_genesis/_core/worker.py
+++ b/blocks_genesis/_core/worker.py
@@ -12,6 +12,8 @@ from blocks_genesis._database.mongo_context import MongoDbContextProvider
 from blocks_genesis._message.azure.azure_message_client import AzureMessageClient
 from blocks_genesis._message.azure.azure_message_worker import AzureMessageWorker
 from blocks_genesis._message.azure.config_azure_service_bus import ConfigAzureServiceBus
+from blocks_genesis._message.rabbit_mq.rabbit_message_client import RabbitMessageClient
+from blocks_genesis._message.rabbit_mq.rabbit_message_worker import RabbitMessageWorker
 from blocks_genesis._message.event_registry import EventRegistry
 from blocks_genesis._message.message_configuration import MessageConfiguration
 from blocks_genesis._lmt.log_config import configure_logger
@@ -33,7 +35,7 @@ class WorkerConsoleApp:
                 Handlers can be callables or classes with a 'handle' method.
                 Defaults to an empty dictionary if not provided.
         """
-        self.message_worker: AzureMessageWorker = None
+        self.message_worker = None
         self.name = name
         self.logger = logging.getLogger(__name__)
         self.message_config = message_config
@@ -76,13 +78,21 @@ class WorkerConsoleApp:
 
             
             self.message_config.connection = self.message_config.connection or get_blocks_secret().MessageConnectionString
-            ConfigAzureServiceBus().configure_queue_and_topic(self.message_config)
-            AzureMessageClient.initialize(self.message_config)
+            self.message_config.resolve_provider()
 
-            self.message_worker = AzureMessageWorker(self.message_config)
-            self.message_worker.initialize()
+            if self.message_config.rabbit_mq_configuration is not None:
+                RabbitMessageClient.initialize(self.message_config)
+                self.message_worker = RabbitMessageWorker(self.message_config)
+                self.message_worker.initialize()
+                self.logger.info("RabbitMQ Message Worker initialized and ready")
 
-            self.logger.info("Azure Message Worker initialized and ready")
+            if self.message_config.azure_service_bus_configuration is not None:
+                ConfigAzureServiceBus().configure_queue_and_topic(self.message_config)
+                AzureMessageClient.initialize(self.message_config)
+                self.message_worker = AzureMessageWorker(self.message_config)
+                self.message_worker.initialize()
+                self.logger.info("Azure Message Worker initialized and ready")
+
             yield self.message_worker
 
         except Exception as ex:
@@ -100,9 +110,9 @@ class WorkerConsoleApp:
         self.logger.info("Cleaning up services...")
 
         if self.message_worker:
-            self.logger.info("Stopping Azure Message Worker...")
+            self.logger.info("Stopping Message Worker...")
             await self.message_worker.stop()
-            self.logger.info("Azure Message Worker stopped.")
+            self.logger.info("Message Worker stopped.")
 
         if hasattr(MongoHandler, '_mongo_logger') and MongoHandler._mongo_logger:
             self.logger.info("Stopping Mongo log exporter...")

--- a/blocks_genesis/_message/azure/azure_message_client.py
+++ b/blocks_genesis/_message/azure/azure_message_client.py
@@ -5,6 +5,7 @@ from dataclasses import asdict, is_dataclass
 from typing import Any, Dict, Optional
 
 from asyncio import Lock
+from pydantic import BaseModel
 from collections import defaultdict
 from datetime import datetime
 from azure.servicebus.aio import ServiceBusClient, ServiceBusSender
@@ -43,6 +44,7 @@ class AzureMessageClient(MessageClient):
         with cls._singleton_lock:
             if cls._instance is None:
                 cls._instance = cls(message_config)
+                MessageClient.set_active_instance(cls._instance)
                 logger.info("AzureMessageClient singleton initialized.")
 
     @classmethod
@@ -109,10 +111,26 @@ class AzureMessageClient(MessageClient):
                 }
             )
 
-            await sender.send_messages(sb_message)
+            try:
+                await sender.send_messages(sb_message)
+                logger.info(
+                    "Message published to Azure Service Bus %s '%s'",
+                    "topic" if is_topic else "queue",
+                    consumer_message.consumer_name,
+                )
+                return True
+            except Exception as ex:
+                logger.error(
+                    "Failed to publish message to Azure Service Bus '%s': %s",
+                    consumer_message.consumer_name,
+                    str(ex),
+                )
+                raise
 
     def _serialize_payload(self, payload):
-        if is_dataclass(payload):
+        if isinstance(payload, BaseModel):
+            return payload.model_dump()
+        elif is_dataclass(payload):
             return asdict(payload)
         elif isinstance(payload, dict):
             return payload
@@ -121,11 +139,11 @@ class AzureMessageClient(MessageClient):
         else:
             raise TypeError(f"Unsupported payload type: {type(payload)}")
 
-    async def send_to_consumer_async(self, consumer_message: ConsumerMessage):
-        await self._send_to_azure_bus_async(consumer_message)
+    async def send_to_consumer_async(self, consumer_message: ConsumerMessage) -> bool:
+        return await self._send_to_azure_bus_async(consumer_message)
 
-    async def send_to_mass_consumer_async(self, consumer_message: ConsumerMessage):
-        await self._send_to_azure_bus_async(consumer_message, is_topic=True)
+    async def send_to_mass_consumer_async(self, consumer_message: ConsumerMessage) -> bool:
+        return await self._send_to_azure_bus_async(consumer_message, is_topic=True)
 
     async def close(self):
         await self._client.close()

--- a/blocks_genesis/_message/message_client.py
+++ b/blocks_genesis/_message/message_client.py
@@ -1,13 +1,26 @@
 from abc import ABC, abstractmethod
+from typing import Optional
 
 from blocks_genesis._message.consumer_message import ConsumerMessage
 
 
 class MessageClient(ABC):
+    _active_instance: Optional["MessageClient"] = None
+
     @abstractmethod
-    async def send_to_consumer_async(self, consumer_message: ConsumerMessage) -> None:
+    async def send_to_consumer_async(self, consumer_message: ConsumerMessage) -> bool:
         pass
 
     @abstractmethod
-    async def send_to_mass_consumer_async(self, consumer_message: ConsumerMessage) -> None:
+    async def send_to_mass_consumer_async(self, consumer_message: ConsumerMessage) -> bool:
         pass
+
+    @classmethod
+    def set_active_instance(cls, instance: "MessageClient") -> None:
+        cls._active_instance = instance
+
+    @classmethod
+    def get_instance(cls) -> "MessageClient":
+        if cls._active_instance is None:
+            raise RuntimeError("No MessageClient has been initialized. Configure Azure or RabbitMQ first.")
+        return cls._active_instance

--- a/blocks_genesis/_message/message_configuration.py
+++ b/blocks_genesis/_message/message_configuration.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 from datetime import timedelta
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field
 
@@ -29,11 +30,89 @@ class AzureServiceBusConfiguration(BaseModel):
         self.topics = [t.lower() for t in topic_list if t and t.strip()]
 
 
+class ConsumerSubscription(BaseModel):
+    queue_name: str
+    exchange_name: str = ""
+    prefetch_count: int = 5
+    exchange_type: str = "fanout"
+    routing_key: str = ""
+    should_bypass_authorization: bool = False
+    durable: bool = True
+    parallel_processing: bool = False
+
+    @classmethod
+    def bind_to_queue(cls, queue_name: str, prefetch_count: int = 5) -> "ConsumerSubscription":
+        """Creates a subscription that binds directly to a queue."""
+        return cls(queue_name=queue_name, exchange_name="", prefetch_count=prefetch_count)
+
+    @classmethod
+    def bind_to_queue_via_exchange(
+        cls,
+        queue_name: str,
+        exchange_name: str,
+        prefetch_count: int = 5,
+        parallel_processing: bool = False,
+    ) -> "ConsumerSubscription":
+        """Creates a subscription that binds a queue via an exchange."""
+        return cls(
+            queue_name=queue_name,
+            exchange_name=exchange_name,
+            prefetch_count=prefetch_count,
+            parallel_processing=parallel_processing,
+        )
+
+
+class RabbitMqConfiguration(BaseModel):
+    consumer_subscriptions: List[ConsumerSubscription] = Field(default_factory=list)
+    message_ttl_seconds: int = 0
+
 
 class MessageConfiguration(BaseModel):
     connection: Optional[str] = None
     service_name: Optional[str] = None
+    queues: List[str] = Field(default_factory=list)
+    topics: List[str] = Field(default_factory=list)
+    consumer_subscriptions: Optional[List[ConsumerSubscription]] = None
     azure_service_bus_configuration: Optional[AzureServiceBusConfiguration] = None
+    rabbit_mq_configuration: Optional[RabbitMqConfiguration] = None
 
     def get_subscription_name(self, topic_name: str) -> str:
         return f"{topic_name}_sub_{self.service_name}"
+
+    def resolve_provider(self) -> None:
+        """
+        Auto-detects the messaging provider from the connection string and populates
+        the appropriate sub-configuration if neither is already set.
+        amqp:// or amqps:// → RabbitMQ, otherwise → Azure Service Bus.
+        Mirrors the .NET Constants.GetMessageConfiguration pattern.
+        """
+        if self.azure_service_bus_configuration or self.rabbit_mq_configuration:
+            return
+
+        if not self.connection:
+            return
+
+        provider = _get_provider(self.connection)
+
+        if provider == "rabbitmq":
+            self.rabbit_mq_configuration = RabbitMqConfiguration(
+                consumer_subscriptions=[
+                    ConsumerSubscription.bind_to_queue(q) for q in self.queues
+                ] + (self.consumer_subscriptions or []),
+            )
+        else:
+            self.azure_service_bus_configuration = AzureServiceBusConfiguration(
+                queues=self.queues,
+                topics=self.topics,
+            )
+
+
+def _get_provider(connection_string: str) -> str:
+    """Detects the messaging provider from the connection string scheme."""
+    try:
+        parsed = urlparse(connection_string)
+        if parsed.scheme.lower() in ("amqp", "amqps"):
+            return "rabbitmq"
+    except Exception:
+        pass
+    return "azure"

--- a/blocks_genesis/_message/rabbit_mq/__init__.py
+++ b/blocks_genesis/_message/rabbit_mq/__init__.py
@@ -1,0 +1,9 @@
+from blocks_genesis._message.rabbit_mq.rabbit_message_client import RabbitMessageClient
+from blocks_genesis._message.rabbit_mq.rabbit_message_worker import RabbitMessageWorker
+from blocks_genesis._message.rabbit_mq.rabbit_mq_service import RabbitMqService
+
+__all__ = [
+    "RabbitMessageClient",
+    "RabbitMessageWorker",
+    "RabbitMqService",
+]

--- a/blocks_genesis/_message/rabbit_mq/rabbit_message_client.py
+++ b/blocks_genesis/_message/rabbit_mq/rabbit_message_client.py
@@ -1,0 +1,183 @@
+import asyncio
+import json
+import logging
+import threading
+from dataclasses import asdict, is_dataclass
+from datetime import timedelta
+from typing import Optional
+
+import aio_pika
+from pydantic import BaseModel
+
+from blocks_genesis._auth.blocks_context import BlocksContextManager
+from blocks_genesis._lmt.activity import Activity
+from blocks_genesis._message.consumer_message import ConsumerMessage
+from blocks_genesis._message.event_message import EventMessage
+from blocks_genesis._message.message_client import MessageClient
+from blocks_genesis._message.message_configuration import MessageConfiguration
+from blocks_genesis._message.rabbit_mq.rabbit_mq_service import RabbitMqService
+
+logger = logging.getLogger(__name__)
+
+
+class RabbitMessageClient(MessageClient):
+    """
+    Singleton RabbitMQ message publisher.
+    Mirrors AzureMessageClient — call initialize() once at startup,
+    then use get_instance() wherever publishing is needed.
+    """
+
+    _instance: Optional["RabbitMessageClient"] = None
+    _singleton_lock = threading.Lock()
+
+    def __init__(self, message_config: MessageConfiguration):
+        self._message_config = message_config
+        self._rabbit_mq_service = RabbitMqService(message_config)
+        self._initialized = False
+        self._init_lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Singleton lifecycle
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def initialize(cls, message_config: MessageConfiguration) -> None:
+        with cls._singleton_lock:
+            if cls._instance is None:
+                cls._instance = cls(message_config)
+                MessageClient.set_active_instance(cls._instance)
+                logger.info("RabbitMessageClient singleton initialized.")
+
+    @classmethod
+    def get_instance(cls) -> "RabbitMessageClient":
+        if cls._instance is None:
+            raise RuntimeError("RabbitMessageClient not initialized. Call initialize() first.")
+        return cls._instance
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _ensure_initialized_async(self) -> None:
+        if self._initialized:
+            return
+        async with self._init_lock:
+            if self._initialized:
+                return
+            await self._rabbit_mq_service.create_connection_async()
+            channel = self._rabbit_mq_service.channel
+            channel.return_callbacks.add(self._on_message_returned)
+            await self._rabbit_mq_service.initialize_subscriptions_async()
+            self._initialized = True
+
+    def _on_message_returned(self, *args) -> None:
+        message = args[-1]  # CallbackCollection passes (collection, message)
+        logger.warning(
+            "Message returned: exchange=%s, routing_key=%s, body=%s",
+            message.exchange,
+            message.routing_key,
+            message.body.decode("utf-8") if message.body else "",
+        )
+
+    def _serialize_payload(self, payload) -> dict:
+        if isinstance(payload, BaseModel):
+            return payload.model_dump()
+        elif is_dataclass(payload):
+            return asdict(payload)
+        elif isinstance(payload, dict):
+            return payload
+        elif isinstance(payload, str):
+            return {"message": payload}
+        else:
+            raise TypeError(f"Unsupported payload type: {type(payload)}")
+
+    async def _send_message_async(
+        self, consumer_message: ConsumerMessage, is_exchange: bool = False
+    ) -> bool:
+        await self._ensure_initialized_async()
+
+        security_context = BlocksContextManager.get_context()
+
+        with Activity("messaging.rabbitmq.send") as activity:
+            activity.set_properties({
+                "messaging.system": "rabbitmq",
+                "messaging.destination.name": consumer_message.consumer_name,
+                "messaging.destination.kind": "exchange" if is_exchange else "queue",
+                "messaging.rabbitmq.routing_key": consumer_message.routing_key or "",
+                "messaging.message_type": consumer_message.payload_type,
+            })
+
+            payload_dict = self._serialize_payload(consumer_message.payload)
+            message_body = EventMessage(
+                body=json.dumps(payload_dict),
+                type=consumer_message.payload_type,
+            )
+
+            headers = {
+                "TenantId": security_context.tenant_id if security_context else "",
+                "TraceId": Activity.get_trace_id(),
+                "SpanId": Activity.get_span_id(),
+                "SecurityContext": consumer_message.context or json.dumps(
+                    security_context.model_dump(mode="json") if security_context else {}
+                ),
+                "Baggage": json.dumps(activity.get_all_root_attributes()),
+            }
+
+            properties: dict = {
+                "delivery_mode": aio_pika.DeliveryMode.PERSISTENT,
+                "headers": headers,
+            }
+
+            ttl = self._message_config.rabbit_mq_configuration.message_ttl_seconds
+            if ttl and ttl > 0:
+                properties["expiration"] = timedelta(seconds=ttl)
+
+            channel = self._rabbit_mq_service.channel
+            message = aio_pika.Message(
+                body=json.dumps(message_body.model_dump()).encode(),
+                **properties,
+            )
+
+            try:
+                if is_exchange:
+                    exchange = await channel.get_exchange(consumer_message.consumer_name)
+                    await exchange.publish(
+                        message,
+                        routing_key=consumer_message.routing_key or "",
+                        mandatory=True,
+                    )
+                else:
+                    await channel.default_exchange.publish(
+                        message,
+                        routing_key=consumer_message.consumer_name,
+                        mandatory=True,
+                    )
+
+                logger.info(
+                    "Message published to %s (is_exchange=%s) with routing_key=%s",
+                    consumer_message.consumer_name,
+                    is_exchange,
+                    consumer_message.routing_key or "",
+                )
+                return True
+            except Exception as ex:
+                logger.error(
+                    "Failed to publish message to %s: %s",
+                    consumer_message.consumer_name,
+                    str(ex),
+                )
+                raise
+
+    # ------------------------------------------------------------------
+    # MessageClient interface
+    # ------------------------------------------------------------------
+
+    async def send_to_consumer_async(self, consumer_message: ConsumerMessage) -> bool:
+        return await self._send_message_async(consumer_message, is_exchange=False)
+
+    async def send_to_mass_consumer_async(self, consumer_message: ConsumerMessage) -> bool:
+        return await self._send_message_async(consumer_message, is_exchange=True)
+
+    async def close(self) -> None:
+        await self._rabbit_mq_service.close()
+        self._initialized = False

--- a/blocks_genesis/_message/rabbit_mq/rabbit_message_worker.py
+++ b/blocks_genesis/_message/rabbit_mq/rabbit_message_worker.py
@@ -1,0 +1,202 @@
+import asyncio
+import json
+import logging
+from typing import List, Optional
+
+import aio_pika
+from aio_pika.abc import AbstractIncomingMessage
+from opentelemetry import trace
+from opentelemetry.trace import SpanKind, StatusCode
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+from blocks_genesis._auth.blocks_context import BlocksContextManager
+from blocks_genesis._message.consumer import Consumer
+from blocks_genesis._message.event_message import EventMessage
+from blocks_genesis._message.message_configuration import ConsumerSubscription, MessageConfiguration
+from blocks_genesis._message.rabbit_mq.rabbit_mq_service import RabbitMqService
+
+logger = logging.getLogger(__name__)
+
+
+class RabbitMessageWorker:
+    """
+    Async RabbitMQ consumer worker.
+    Mirrors the .NET RabbitMessageWorker — uses push-based consuming
+    with explicit ACK after processing (autoAck=false).
+    """
+
+    def __init__(self, message_config: MessageConfiguration):
+        self._message_config = message_config
+        self._consumer = Consumer()
+        self._rabbit_mq_service: Optional[RabbitMqService] = None
+        self._tracer = trace.get_tracer(__name__)
+        self._stop_event = asyncio.Event()
+
+    def initialize(self) -> None:
+        """Creates the RabbitMqService (connection is established during run())."""
+        if not self._message_config.connection:
+            raise ValueError("RabbitMQ connection string is missing in MessageConfiguration.")
+        self._rabbit_mq_service = RabbitMqService(self._message_config)
+        logger.info("RabbitMQ service created and ready to connect.")
+
+    async def run(self) -> None:
+        """Connects, declares queues/exchanges, and starts consuming all subscriptions."""
+        if self._rabbit_mq_service is None:
+            raise RuntimeError("RabbitMessageWorker is not initialized. Call initialize() first.")
+
+        await self._rabbit_mq_service.create_connection_async()
+        await self._rabbit_mq_service.initialize_subscriptions_async()
+
+        channel = self._rabbit_mq_service.channel
+        rabbit_config = self._message_config.rabbit_mq_configuration
+
+        if not rabbit_config or not rabbit_config.consumer_subscriptions:
+            logger.warning("No consumer subscriptions configured for RabbitMQ.")
+            return
+
+        await self._start_consuming(channel, rabbit_config.consumer_subscriptions)
+
+        logger.info("RabbitMQ worker is running and awaiting messages.")
+        # Block until stop() is called
+        await self._stop_event.wait()
+
+    async def _start_consuming(
+        self, channel: aio_pika.abc.AbstractChannel, subscriptions: List[ConsumerSubscription]
+    ) -> None:
+        """
+        Registers a push-based consumer on each queue.
+        Mirrors .NET StartConsumingAsync — uses BasicConsume with autoAck=false.
+        """
+        for subscription in subscriptions:
+            queue = await channel.declare_queue(
+                name=subscription.queue_name,
+                durable=subscription.durable,
+                auto_delete=False,
+            )
+            msg_count = queue.declaration_result.message_count
+            logger.info(
+                "Queue '%s' declared — %d message(s) pending.",
+                subscription.queue_name,
+                msg_count,
+            )
+
+            # Set prefetch per queue (mirrors .NET BasicQos)
+            await channel.set_qos(prefetch_count=subscription.prefetch_count)
+
+            # Register push-based consumer (no_ack=False → explicit ACK required)
+            # IMPORTANT: must use a proper async function, NOT a lambda.
+            # aio_pika checks asyncio.iscoroutinefunction() — lambdas returning
+            # coroutines fail this check and the coroutine is never awaited.
+            consumer_tag = await queue.consume(
+                callback=self._make_callback(subscription),
+                no_ack=False,
+            )
+
+            logger.info(
+                "Started consuming queue: %s, consumer_tag=%s, parallel=%s, prefetch=%d",
+                subscription.queue_name,
+                consumer_tag,
+                subscription.parallel_processing,
+                subscription.prefetch_count,
+            )
+
+    def _make_callback(self, subscription: ConsumerSubscription):
+        """
+        Creates a proper async callback bound to the given subscription.
+        This is necessary because aio_pika uses asyncio.iscoroutinefunction()
+        to decide whether to await the callback — lambdas fail that check.
+        """
+        async def callback(message: AbstractIncomingMessage) -> None:
+            try:
+                if subscription.parallel_processing:
+                    asyncio.create_task(self._process_message(message, subscription))
+                else:
+                    await self._process_message(message, subscription)
+            except Exception:
+                logger.exception("Unhandled error in message callback for queue '%s'", subscription.queue_name)
+        return callback
+
+    async def _process_message(
+        self, message: AbstractIncomingMessage, subscription: ConsumerSubscription
+    ) -> None:
+        """Handles a single incoming message: context → tracing → dispatch → always ACK."""
+        headers = message.headers or {}
+
+        def _decode(val) -> str:
+            if isinstance(val, bytes):
+                return val.decode("utf-8")
+            return str(val) if val is not None else ""
+
+        trace_id = _decode(headers.get("TraceId", ""))
+        span_id = _decode(headers.get("SpanId", ""))
+        tenant_id = _decode(headers.get("TenantId", ""))
+        security_context_raw = _decode(headers.get("SecurityContext", ""))
+        baggage_str = _decode(headers.get("Baggage", "{}"))
+
+        # Restore security context (mirrors .NET: BlocksContext.SetContext)
+        if security_context_raw:
+            try:
+                sc = json.loads(security_context_raw)
+                BlocksContextManager.set_context(BlocksContextManager.create(**sc))
+            except Exception:
+                logger.warning("Could not parse SecurityContext header.", exc_info=True)
+
+        # Restore trace context
+        context = None
+        if trace_id and span_id:
+            try:
+                context = TraceContextTextMapPropagator().extract(
+                    {"traceparent": f"00-{trace_id}-{span_id}-01"}
+                )
+            except Exception:
+                logger.warning("Could not extract trace context from headers.", exc_info=True)
+
+        with self._tracer.start_as_current_span(
+            "process.messaging.rabbitmq",
+            context=context,
+            kind=SpanKind.CONSUMER,
+        ) as span:
+            span.set_attribute("messaging.system", "rabbitmq")
+            span.set_attribute("messaging.destination.name", subscription.queue_name)
+            span.set_attribute("SecurityContext", security_context_raw)
+            span.set_attribute("baggage.TenantId", tenant_id)
+            span.set_attribute("usage", True)
+
+            try:
+                baggages = json.loads(baggage_str)
+                for key, value in baggages.items():
+                    span.set_attribute(f"baggage.{key}", str(value))
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Invalid baggage JSON in message headers.")
+
+            body_bytes = message.body
+            body_str = body_bytes.decode("utf-8") if isinstance(body_bytes, (bytes, bytearray)) else str(body_bytes)
+            span.set_attribute("message.body", body_str)
+            logger.info(
+                "Received RabbitMQ message on queue '%s'. Body: %s",
+                subscription.queue_name,
+                body_str,
+            )
+
+            try:
+                event = EventMessage(**json.loads(body_str))
+                await self._consumer.process_message(event.type, event.body)
+                span.set_status(StatusCode.OK, "Message processed successfully")
+                logger.info("Message processed successfully.")
+            except Exception as ex:
+                logger.exception("Error processing RabbitMQ message.")
+                span.set_status(StatusCode.ERROR, str(ex))
+                span.set_attribute("error", str(ex))
+            finally:
+                # Always ACK — mirrors .NET: BasicAckAsync in finally block
+                await message.ack()
+                BlocksContextManager.clear_context()
+
+    async def stop(self) -> None:
+        """Signals the worker to stop and closes the RabbitMQ connection."""
+        self._stop_event.set()
+
+        if self._rabbit_mq_service:
+            await self._rabbit_mq_service.close()
+
+        logger.info("RabbitMessageWorker stopped.")

--- a/blocks_genesis/_message/rabbit_mq/rabbit_mq_service.py
+++ b/blocks_genesis/_message/rabbit_mq/rabbit_mq_service.py
@@ -1,0 +1,93 @@
+import logging
+
+import aio_pika
+from aio_pika.abc import AbstractChannel, AbstractConnection
+
+from blocks_genesis._message.message_configuration import MessageConfiguration
+
+logger = logging.getLogger(__name__)
+
+
+class RabbitMqService:
+    """
+    Manages the aio_pika connection and channel for RabbitMQ.
+    Handles queue/exchange declaration and bindings based on MessageConfiguration.
+    """
+
+    def __init__(self, config: MessageConfiguration):
+        self._config = config
+        self._connection: AbstractConnection | None = None
+        self._channel: AbstractChannel | None = None
+
+    @property
+    def channel(self) -> AbstractChannel:
+        if self._channel is None:
+            raise RuntimeError("RabbitMQ channel has not been initialized. Call create_connection_async() first.")
+        return self._channel
+
+    async def create_connection_async(self):
+        """Establishes a robust (auto-recovering) connection and opens a channel."""
+        try:
+            self._connection = await aio_pika.connect_robust(
+                self._config.connection,
+                timeout=62,
+            )
+            self._channel = await self._connection.channel()
+            logger.info("Successfully established RabbitMQ connection and channel.")
+        except Exception:
+            logger.exception("An error occurred while creating the RabbitMQ connection.")
+            raise
+
+    async def initialize_subscriptions_async(self):
+        """
+        Declares queues, exchanges, and bindings for every ConsumerSubscription
+        defined in the RabbitMqConfiguration.
+        """
+        if self._channel is None:
+            raise RuntimeError("RabbitMQ channel is not initialized.")
+
+        rabbit_config = self._config.rabbit_mq_configuration
+        if not rabbit_config:
+            return
+
+        for subscription in rabbit_config.consumer_subscriptions:
+            queue = await self._channel.declare_queue(
+                name=subscription.queue_name,
+                durable=subscription.durable,
+                auto_delete=False,
+            )
+
+            if subscription.exchange_name:
+                exchange_type = aio_pika.ExchangeType(subscription.exchange_type)
+                exchange = await self._channel.declare_exchange(
+                    name=subscription.exchange_name,
+                    type=exchange_type,
+                    durable=subscription.durable,
+                    auto_delete=False,
+                )
+                await queue.bind(exchange=exchange, routing_key=subscription.routing_key)
+
+            await self._channel.set_qos(prefetch_count=subscription.prefetch_count)
+            logger.info(
+                "RabbitMQ subscription initialized: queue=%s, exchange=%s, routing_key=%s, prefetch=%d",
+                subscription.queue_name,
+                subscription.exchange_name or "(direct)",
+                subscription.routing_key or "",
+                subscription.prefetch_count,
+            )
+
+        logger.info("RabbitMQ subscriptions initialized successfully.")
+
+    async def close(self):
+        """Gracefully closes the channel and connection."""
+        if self._channel and not self._channel.is_closed:
+            try:
+                await self._channel.close()
+            except Exception:
+                logger.warning("Error while closing RabbitMQ channel.", exc_info=True)
+
+        if self._connection and not self._connection.is_closed:
+            try:
+                await self._connection.close()
+            except Exception:
+                logger.warning("Error while closing RabbitMQ connection.", exc_info=True)

--- a/blocks_genesis/_middlewares/global_exception_middleware.py
+++ b/blocks_genesis/_middlewares/global_exception_middleware.py
@@ -1,4 +1,5 @@
 import logging
+from fastapi import HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -16,6 +17,8 @@ class GlobalExceptionHandlerMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         try:
             return await call_next(request)
+        except HTTPException:
+            raise
         except Exception as exc:
             return await self.handle_exception(request, exc)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "opentelemetry-instrumentation-redis>=0.54b1",
     "aiohttp>=3.12.9",
     "azure-servicebus>=7.14.2",
+    "aio-pika>=9.0.0",
     "cors>=1.0.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,9 +1,44 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
     "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "aio-pika"
+version = "9.5.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "aiormq", version = "6.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+    { name = "yarl", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/52/fe35c898bce5cc8af839ba786b38f7db8932aac48a67ba8ca7de3b074e07/aio_pika-9.5.6.tar.gz", hash = "sha256:5013f429e1235e1ce8df054a821e0eea140ea9afc94a09725b96590ea2dad001", size = 47308, upload-time = "2025-08-05T14:18:35.949Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/fb/c1cfb7cb98ccd2abdc91e170e7ba0e1e3088b6a9d051e4f2899d3249a231/aio_pika-9.5.6-py3-none-any.whl", hash = "sha256:47b532419185cf1105ae18daa45a5052ff98064915c5e080b2433431fe808193", size = 54303, upload-time = "2025-08-05T14:18:34.62Z" },
+]
+
+[[package]]
+name = "aio-pika"
+version = "9.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "aiormq", version = "6.9.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "yarl", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/3e/8e8513214ed7ceed6bad8b71f7fe196d54ef2277c135bf7960ed715d4227/aio_pika-9.6.1.tar.gz", hash = "sha256:7a130c51a413cfcd04c3322f6a0ab08c38eb9918de1e476f6d34bbf41fc8d2b0", size = 66809, upload-time = "2026-02-23T15:41:52.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/24/59a1644995f7a0245588a1761d4b515fc63b7a6038310ead2b07eb44cd8b/aio_pika-9.6.1-py3-none-any.whl", hash = "sha256:0fda50fbbdeb6c5b7399730a2286751074dfe6e52a20119a71aef112d4863fd1", size = 52022, upload-time = "2026-02-23T15:41:51.357Z" },
 ]
 
 [[package]]
@@ -116,6 +151,38 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/16/70c4e42ed6a04f78fb58d1a46500a6ce560741d13afde2a5f33840746a5f/aiohttp-3.12.15-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:14954a2988feae3987f1eb49c706bff39947605f4b6fa4027c1d75743723eb09", size = 1640539, upload-time = "2025-07-29T05:52:25.733Z" },
     { url = "https://files.pythonhosted.org/packages/fe/1d/a7eb5fa8a6967117c5c0ad5ab4b1dec0d21e178c89aa08bc442a0b836392/aiohttp-3.12.15-cp39-cp39-win32.whl", hash = "sha256:b784d6ed757f27574dca1c336f968f4e81130b27595e458e69457e6878251f5d", size = 430164, upload-time = "2025-07-29T05:52:27.905Z" },
     { url = "https://files.pythonhosted.org/packages/14/25/e0cf8793aedc41c6d7f2aad646a27e27bdacafe3b402bb373d7651c94d73/aiohttp-3.12.15-cp39-cp39-win_amd64.whl", hash = "sha256:86ceded4e78a992f835209e236617bffae649371c4a50d5e5a3987f237db84b8", size = 453370, upload-time = "2025-07-29T05:52:29.936Z" },
+]
+
+[[package]]
+name = "aiormq"
+version = "6.8.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "pamqp", marker = "python_full_version < '3.10'" },
+    { name = "yarl", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/79/5397756a8782bf3d0dce392b48260c3ec81010f16bef8441ff03505dccb4/aiormq-6.8.1.tar.gz", hash = "sha256:a964ab09634be1da1f9298ce225b310859763d5cf83ef3a7eae1a6dc6bd1da1a", size = 30528, upload-time = "2024-09-04T11:16:38.655Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/be/1a613ae1564426f86650ff58c351902895aa969f7e537e74bfd568f5c8bf/aiormq-6.8.1-py3-none-any.whl", hash = "sha256:5da896c8624193708f9409ffad0b20395010e2747f22aa4150593837f40aa017", size = 31174, upload-time = "2024-09-04T11:16:37.238Z" },
+]
+
+[[package]]
+name = "aiormq"
+version = "6.9.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "pamqp", marker = "python_full_version >= '3.10'" },
+    { name = "yarl", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/b0/85cb8066acc2df8166f743bdcd793e7179f473a7db746a543bcd40fdac7b/aiormq-6.9.3.tar.gz", hash = "sha256:39f57d85650267aebefca162a523e9e000db02468d4fceccb3c5399f378ddabe", size = 45672, upload-time = "2026-02-22T21:04:49.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/9b/be86ea5a73010b437bb5f9511d1fcbb828cdf8eddde0c6f2b38006b9ce92/aiormq-6.9.3-py3-none-any.whl", hash = "sha256:fe2e9f7c99d24dde5f7e1ca8a7da2dc5bab9ae5758fd7599b60d34b6b278926e", size = 27939, upload-time = "2026-02-22T21:04:48.208Z" },
 ]
 
 [[package]]
@@ -1268,6 +1335,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pamqp"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/62/35bbd3d3021e008606cd0a9532db7850c65741bbf69ac8a3a0d8cfeb7934/pamqp-3.3.0.tar.gz", hash = "sha256:40b8795bd4efcf2b0f8821c1de83d12ca16d5760f4507836267fd7a02b06763b", size = 30993, upload-time = "2024-01-12T20:37:25.085Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/8d/c1e93296e109a320e508e38118cf7d1fc2a4d1c2ec64de78565b3c445eb5/pamqp-3.3.0-py2.py3-none-any.whl", hash = "sha256:c901a684794157ae39b52cbf700db8c9aae7a470f13528b9d7b4e5f7202f8eb0", size = 33848, upload-time = "2024-01-12T20:37:21.359Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1751,9 +1827,11 @@ wheels = [
 
 [[package]]
 name = "seliseblocks-genesis"
-version = "0.2.17"
+version = "0.2.24"
 source = { editable = "." }
 dependencies = [
+    { name = "aio-pika", version = "9.5.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "aio-pika", version = "9.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "aiohttp" },
     { name = "azure-identity" },
     { name = "azure-keyvault-secrets" },
@@ -1781,6 +1859,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aio-pika", specifier = ">=9.0.0" },
     { name = "aiohttp", specifier = ">=3.12.9" },
     { name = "azure-identity", specifier = ">=1.7.0" },
     { name = "azure-keyvault-secrets", specifier = ">=4.3.0" },


### PR DESCRIPTION
## Objective

Enable `blocks-genesis-py` to support **RabbitMQ** as a first-class message broker alongside the existing **Azure Service Bus**, with automatic provider detection based on the connection string. This allows consuming projects (e.g., `blocks-ai-py`) to switch between brokers without any code changes — only the connection string determines which provider is used.

## Technical Explanation

### Why RabbitMQ Support?

The .NET counterpart (`blocks-genesis-net`) already supports both Azure Service Bus and RabbitMQ through its `Genesis.Message.Rabbit.Mq` namespace. The Python genesis package only supported Azure Service Bus, forcing Python-based services to use Azure even in environments where RabbitMQ is the preferred broker. This PR brings the Python package to feature parity with .NET.

### Dynamic Provider Detection

Rather than requiring consuming projects to explicitly configure a provider, the system auto-detects the broker from the connection string scheme:
- `amqp://` or `amqps://` → **RabbitMQ**
- Everything else (e.g., `Endpoint=sb://...`) → **Azure Service Bus**

This is implemented via `MessageConfiguration.resolve_provider()`, which mirrors the .NET `Constants.GetMessageConfiguration` pattern. When called, it populates either `rabbit_mq_configuration` or `azure_service_bus_configuration` based on the detected provider, and both `api.py` and `worker.py` use this to initialize the correct client and worker.

### Provider-Agnostic MessageClient Singleton

A new `MessageClient.get_instance()` / `set_active_instance()` pattern was added to the abstract base class. Whichever provider is initialized (RabbitMQ or Azure) registers itself as the active instance. Consuming code calls `MessageClient.get_instance()` without knowing which provider is behind it.

### Push-Based RabbitMQ Consuming

The RabbitMQ worker uses **push-based consuming** (`queue.consume(callback)`) rather than pull-based iteration, matching the .NET `BasicConsumeAsync` pattern. A key implementation detail: aio_pika checks `asyncio.iscoroutinefunction()` on the callback to decide whether to `await` it. Lambda functions returning coroutines fail this check, so the worker uses a `_make_callback()` factory that returns a proper `async def` function.

### Explicit ACK Behavior

Messages are always ACK'd in a `finally` block, even on processing failure. This matches the .NET `BasicAckAsync` behavior in `RabbitMessageWorker.cs` — failed messages are acknowledged (not requeued) to prevent poison message loops.

## Code Changes

### New Files
| File | Description |
|------|-------------|
| `blocks_genesis/_message/rabbit_mq/rabbit_message_client.py` | Singleton RabbitMQ publisher with async initialization, publisher confirms (`mandatory=True`), return callbacks for unroutable messages, and OpenTelemetry tracing |
| `blocks_genesis/_message/rabbit_mq/rabbit_message_worker.py` | Async RabbitMQ consumer worker with push-based consuming, explicit ACK, security context propagation, trace context restoration, and parallel processing support |
| `blocks_genesis/_message/rabbit_mq/rabbit_mq_service.py` | Connection/channel management, queue/exchange declaration with bindings, QoS configuration, and graceful close |
| `blocks_genesis/_message/rabbit_mq/__init__.py` | Module exports |

### Modified Files
| File | Change |
|------|--------|
| `blocks_genesis/_message/message_client.py` | Added `_active_instance` singleton with `get_instance()` / `set_active_instance()`; changed return types from `None` to `bool` |
| `blocks_genesis/_message/message_configuration.py` | Added `ConsumerSubscription`, `RabbitMqConfiguration` models and `resolve_provider()` auto-detection logic |
| `blocks_genesis/_message/azure/azure_message_client.py` | Added `BaseModel` serialization support in `_serialize_payload()`, `set_active_instance()` call on init, try/except with logging around publish, `bool` return types |
| `blocks_genesis/_core/api.py` | Dynamic provider initialization — detects broker from connection string and initializes the correct client; graceful close for both providers |
| `blocks_genesis/_core/worker.py` | Dynamic worker initialization — creates `RabbitMessageWorker` or `AzureMessageWorker` based on resolved provider; provider-agnostic cleanup |
| `blocks_genesis/_middlewares/global_exception_middleware.py` | Added `except HTTPException: raise` to prevent intentional HTTP status codes (401, 404, etc.) from being swallowed as 500 errors |
| `blocks_genesis/__init__.py` | Added exports for `RabbitMessageClient`, `RabbitMqConfiguration`, `ConsumerSubscription` |
| `pyproject.toml` | Added `aio-pika>=9.0.0` dependency |

## Adaptations Required for Consuming Projects

To adopt this change in a consuming project (e.g., `blocks-ai-py`):

1. **No code changes needed** if already using `MessageClient.get_instance()` — the correct provider is resolved automatically from the connection string.

2. **Update `MessageConfiguration`** to use the new `queues` field instead of configuring `AzureServiceBusConfiguration` directly:
   ```python
   # Before (Azure-only)
   message_config = MessageConfiguration(
       azure_service_bus_configuration=AzureServiceBusConfiguration(queues=["my-queue"])
   )

   # After (provider-agnostic)
   message_config = MessageConfiguration(queues=["my-queue"])
   # Provider is auto-detected when resolve_provider() is called during startup
   ```

3. **For RabbitMQ-specific features** (exchanges, routing keys, prefetch tuning), use `ConsumerSubscription` directly:
   ```python
   from blocks_genesis import ConsumerSubscription, MessageConfiguration

   message_config = MessageConfiguration(
       consumer_subscriptions=[
           ConsumerSubscription.bind_to_queue_via_exchange("my-queue", "my-exchange")
       ]
   )
   ```

4. **Connection string** is the only differentiator:
   - `amqp://user:pass@host:5672/` → RabbitMQ
   - `Endpoint=sb://namespace.servicebus.windows.net/...` → Azure Service Bus

5. **Upgrade `blocks-genesis-py`** dependency to pick up the new version with `aio-pika` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)